### PR TITLE
Allow users to use an existing secret

### DIFF
--- a/charts/pgcat/templates/deployment.yaml
+++ b/charts/pgcat/templates/deployment.yaml
@@ -62,5 +62,5 @@ spec:
       volumes:
       - secret:
           defaultMode: 420
-          secretName: {{ include "pgcat.fullname" . }}
+          secretName: {{ default (include "pgcat.fullname" .) .Values.pgcatSecretName }}
         name: config

--- a/charts/pgcat/templates/secret.yaml
+++ b/charts/pgcat/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pgcatSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -84,3 +85,4 @@ stringData:
     database = {{ $shard.database | quote }}
     {{-   end }}
     {{- end }}
+{{- end -}}

--- a/charts/pgcat/values.yaml
+++ b/charts/pgcat/values.yaml
@@ -148,8 +148,12 @@ tolerations: []
 ##
 affinity: {}
 
+## Use an existing secret that contains pgcat configuration
+pgcatSecretName: ""
+
 ## PgCat configuration
 ## @param configuration [object]
+## Will be ignored if pgcatSecretName is set
 configuration:
   ## General pooler settings
   ## @param [object]


### PR DESCRIPTION
Storing the secrets in a value file can be problematic, so allow the users to specify and existing Kubernetes Secret that holds pgcat configuration